### PR TITLE
Remove .upper() from _modify_sub

### DIFF
--- a/polygon/streaming/async_streaming.py
+++ b/polygon/streaming/async_streaming.py
@@ -349,7 +349,7 @@ class AsyncStreamClient:
 
         return _apis, _handlers
 
-    async def _modify_sub(self, symbols: Union[str, list, None], action: str = 'subscribe', _prefix: str = 'T.'):
+    async def _modify_sub(self, symbols: Union[str, list, None], action: str = 'subscribe', _prefix: str = 'T.', convert_case=True):
         """
         Internal Function to send subscribe or unsubscribe requests to websocket. You should prefer using the
         corresponding methods to subscribe or unsubscribe to streams.
@@ -400,7 +400,7 @@ class AsyncStreamClient:
 
         self._handlers[_prefix] = handler_function
 
-        await self._modify_sub(symbols, _prefix=f'{_prefix}.')
+        await self._modify_sub(symbols, _prefix=f'{_prefix}.', convert_case=convert_case)
 
     async def unsubscribe_stock_trades(self, symbols: list = None):
         """
@@ -428,7 +428,7 @@ class AsyncStreamClient:
 
         self._handlers[_prefix] = handler_function
 
-        await self._modify_sub(symbols, _prefix=f'{_prefix}.')
+        await self._modify_sub(symbols, _prefix=f'{_prefix}.', convert_case=convert_case)
 
     async def unsubscribe_stock_quotes(self, symbols: list = None):
         """
@@ -456,7 +456,7 @@ class AsyncStreamClient:
 
         self._handlers[_prefix] = handler_function
 
-        await self._modify_sub(symbols, _prefix=f'{_prefix}.')
+        await self._modify_sub(symbols, _prefix=f'{_prefix}.', convert_case=convert_case)
 
     async def unsubscribe_stock_minute_aggregates(self, symbols: list = None):
         """
@@ -484,7 +484,7 @@ class AsyncStreamClient:
 
         self._handlers[_prefix] = handler_function
 
-        await self._modify_sub(symbols, _prefix=f'{_prefix}.')
+        await self._modify_sub(symbols, _prefix=f'{_prefix}.', convert_case=convert_case)
 
     async def unsubscribe_stock_second_aggregates(self, symbols: list = None):
         """
@@ -512,7 +512,7 @@ class AsyncStreamClient:
 
         self._handlers[_prefix] = handler_function
 
-        await self._modify_sub(symbols, _prefix=f'{_prefix}.')
+        await self._modify_sub(symbols, _prefix=f'{_prefix}.', convert_case=convert_case)
 
     async def unsubscribe_stock_limit_up_limit_down(self, symbols: list = None):
         """
@@ -540,7 +540,7 @@ class AsyncStreamClient:
 
         self._handlers[_prefix] = handler_function
 
-        await self._modify_sub(symbols, _prefix=f'{_prefix}.')
+        await self._modify_sub(symbols, _prefix=f'{_prefix}.', convert_case=convert_case)
 
     async def unsubscribe_stock_imbalances(self, symbols: list = None):
         """
@@ -570,7 +570,7 @@ class AsyncStreamClient:
 
         self._handlers[_prefix] = handler_function
 
-        await self._modify_sub(symbols, _prefix=f'{_prefix}.')
+        await self._modify_sub(symbols, _prefix=f'{_prefix}.', convert_case=convert_case)
 
     async def unsubscribe_option_trades(self, symbols: list = None):
         """
@@ -600,7 +600,7 @@ class AsyncStreamClient:
 
         self._handlers[_prefix] = handler_function
 
-        await self._modify_sub(symbols, _prefix=f'{_prefix}.')
+        await self._modify_sub(symbols, _prefix=f'{_prefix}.', convert_case=convert_case)
 
     async def unsubscribe_option_quotes(self, symbols: list = None):
         """
@@ -630,7 +630,7 @@ class AsyncStreamClient:
 
         self._handlers[_prefix] = handler_function
 
-        await self._modify_sub(symbols, _prefix=f'{_prefix}.')
+        await self._modify_sub(symbols, _prefix=f'{_prefix}.', convert_case=convert_case)
 
     async def unsubscribe_option_minute_aggregates(self, symbols: list = None):
         """
@@ -660,7 +660,7 @@ class AsyncStreamClient:
 
         self._handlers[_prefix] = handler_function
 
-        await self._modify_sub(symbols, _prefix=f'{_prefix}.')
+        await self._modify_sub(symbols, _prefix=f'{_prefix}.', convert_case=convert_case)
 
     async def unsubscribe_option_second_aggregates(self, symbols: list = None):
         """
@@ -691,7 +691,7 @@ class AsyncStreamClient:
 
         self._handlers[_prefix] = handler_function
 
-        await self._modify_sub(symbols, _prefix=f'{_prefix}.')
+        await self._modify_sub(symbols, _prefix=f'{_prefix}.', convert_case=convert_case)
 
     async def unsubscribe_forex_quotes(self, symbols: list = None):
         """
@@ -721,7 +721,7 @@ class AsyncStreamClient:
 
         self._handlers[_prefix] = handler_function
 
-        await self._modify_sub(symbols, _prefix=f'{_prefix}.')
+        await self._modify_sub(symbols, _prefix=f'{_prefix}.', convert_case=convert_case)
 
     async def unsubscribe_forex_minute_aggregates(self, symbols: list = None):
         """
@@ -753,7 +753,7 @@ class AsyncStreamClient:
 
         self._handlers[_prefix] = handler_function
 
-        await self._modify_sub(symbols, _prefix=f'{_prefix}.')
+        await self._modify_sub(symbols, _prefix=f'{_prefix}.', convert_case=convert_case)
 
     async def unsubscribe_crypto_trades(self, symbols: list = None):
         """
@@ -785,7 +785,7 @@ class AsyncStreamClient:
 
         self._handlers[_prefix] = handler_function
 
-        await self._modify_sub(symbols, _prefix=f'{_prefix}.')
+        await self._modify_sub(symbols, _prefix=f'{_prefix}.', convert_case=convert_case)
 
     async def unsubscribe_crypto_quotes(self, symbols: list = None):
         """
@@ -817,7 +817,7 @@ class AsyncStreamClient:
 
         self._handlers[_prefix] = handler_function
 
-        await self._modify_sub(symbols, _prefix=f'{_prefix}.')
+        await self._modify_sub(symbols, _prefix=f'{_prefix}.', convert_case=convert_case)
 
     async def unsubscribe_crypto_minute_aggregates(self, symbols: list = None):
         """
@@ -849,7 +849,7 @@ class AsyncStreamClient:
 
         self._handlers[_prefix] = handler_function
 
-        await self._modify_sub(symbols, _prefix=f'{_prefix}.')
+        await self._modify_sub(symbols, _prefix=f'{_prefix}.', convert_case=convert_case)
 
     async def unsubscribe_crypto_level2_book(self, symbols: list = None):
         """

--- a/polygon/streaming/async_streaming.py
+++ b/polygon/streaming/async_streaming.py
@@ -378,6 +378,9 @@ class AsyncStreamClient:
             symbols = _prefix + '*'
 
         elif isinstance(symbols, list):
+            if convert_case:
+                symbols = [symbol.upper() for symbol in symbols]
+                
             symbols = ','.join([_prefix + symbol for symbol in symbols])
 
         self._subs.append((symbols, action))

--- a/polygon/streaming/async_streaming.py
+++ b/polygon/streaming/async_streaming.py
@@ -349,7 +349,7 @@ class AsyncStreamClient:
 
         return _apis, _handlers
 
-    async def _modify_sub(self, symbols: Union[str, list, None], action: str = 'subscribe', _prefix: str = 'T.', convert_case=True):
+    async def _modify_sub(self, symbols: Union[str, list, None], action: str = 'subscribe', _prefix: str = 'T.', convert_case: bool = True):
         """
         Internal Function to send subscribe or unsubscribe requests to websocket. You should prefer using the
         corresponding methods to subscribe or unsubscribe to streams.
@@ -389,7 +389,7 @@ class AsyncStreamClient:
         await self.WS.send(str(_payload))
 
     # STOCK Streams
-    async def subscribe_stock_trades(self, symbols: list = None, handler_function=None, convert_case=True):
+    async def subscribe_stock_trades(self, symbols: list = None, handler_function=None, convert_case: bool = True):
         """
         Get Real time trades for provided symbol(s)
 
@@ -417,7 +417,7 @@ class AsyncStreamClient:
 
         await self._modify_sub(symbols, action='unsubscribe', _prefix=f'{_prefix}.')
 
-    async def subscribe_stock_quotes(self, symbols: list = None, handler_function=None, convert_case=True):
+    async def subscribe_stock_quotes(self, symbols: list = None, handler_function=None, convert_case: bool = True):
         """
         Get Real time quotes for provided symbol(s)
 
@@ -445,7 +445,7 @@ class AsyncStreamClient:
 
         await self._modify_sub(symbols, action='unsubscribe', _prefix=f'{_prefix}.')
 
-    async def subscribe_stock_minute_aggregates(self, symbols: list = None, handler_function=None, convert_case=True):
+    async def subscribe_stock_minute_aggregates(self, symbols: list = None, handler_function=None, convert_case: bool = True):
         """
         Get Real time Minute Aggregates for provided symbol(s)
 
@@ -473,7 +473,7 @@ class AsyncStreamClient:
 
         await self._modify_sub(symbols, action='unsubscribe', _prefix=f'{_prefix}.')
 
-    async def subscribe_stock_second_aggregates(self, symbols: list = None, handler_function=None, convert_case=True):
+    async def subscribe_stock_second_aggregates(self, symbols: list = None, handler_function=None, convert_case: bool = True):
         """
         Get Real time Seconds Aggregates for provided symbol(s)
 
@@ -501,7 +501,7 @@ class AsyncStreamClient:
 
         await self._modify_sub(symbols, action='unsubscribe', _prefix=f'{_prefix}.')
 
-    async def subscribe_stock_limit_up_limit_down(self, symbols: list = None, handler_function=None, convert_case=True):
+    async def subscribe_stock_limit_up_limit_down(self, symbols: list = None, handler_function=None, convert_case: bool = True):
         """
         Get Real time LULD Events for provided symbol(s)
 
@@ -529,7 +529,7 @@ class AsyncStreamClient:
 
         await self._modify_sub(symbols, action='unsubscribe', _prefix=f'{_prefix}.')
 
-    async def subscribe_stock_imbalances(self, symbols: list = None, handler_function=None, convert_case=True):
+    async def subscribe_stock_imbalances(self, symbols: list = None, handler_function=None, convert_case: bool = True):
         """
         Get Real time Imbalance Events for provided symbol(s)
 
@@ -558,7 +558,7 @@ class AsyncStreamClient:
         await self._modify_sub(symbols, action='unsubscribe', _prefix=f'{_prefix}.')
 
     # OPTIONS Streams
-    async def subscribe_option_trades(self, symbols: list = None, handler_function=None, convert_case=True):
+    async def subscribe_option_trades(self, symbols: list = None, handler_function=None, convert_case: bool = True):
         """
         Get Real time options trades for provided ticker(s)
 
@@ -588,7 +588,7 @@ class AsyncStreamClient:
 
         await self._modify_sub(symbols, action='unsubscribe', _prefix=f'{_prefix}.')
 
-    async def subscribe_option_quotes(self, symbols: list = None, handler_function=None, convert_case=True):
+    async def subscribe_option_quotes(self, symbols: list = None, handler_function=None, convert_case: bool = True):
         """
         Get Real time options quotes for provided ticker(s)
 
@@ -618,7 +618,7 @@ class AsyncStreamClient:
 
         await self._modify_sub(symbols, action='unsubscribe', _prefix=f'{_prefix}.')
 
-    async def subscribe_option_minute_aggregates(self, symbols: list = None, handler_function=None, convert_case=True):
+    async def subscribe_option_minute_aggregates(self, symbols: list = None, handler_function=None, convert_case: bool = True):
         """
         Get Real time options minute aggregates for given ticker(s)
 
@@ -648,7 +648,7 @@ class AsyncStreamClient:
 
         await self._modify_sub(symbols, action='unsubscribe', _prefix=f'{_prefix}.')
 
-    async def subscribe_option_second_aggregates(self, symbols: list = None, handler_function=None, convert_case=True):
+    async def subscribe_option_second_aggregates(self, symbols: list = None, handler_function=None, convert_case: bool = True):
         """
         Get Real time options second aggregates for given ticker(s)
 
@@ -679,7 +679,7 @@ class AsyncStreamClient:
         await self._modify_sub(symbols, action='unsubscribe', _prefix=f'{_prefix}.')
 
     # FOREX Streams
-    async def subscribe_forex_quotes(self, symbols: list = None, handler_function=None, convert_case=True):
+    async def subscribe_forex_quotes(self, symbols: list = None, handler_function=None, convert_case: bool = True):
         """
         Get Real time Forex Quotes for provided symbol(s)
 
@@ -709,7 +709,7 @@ class AsyncStreamClient:
 
         await self._modify_sub(symbols, action='unsubscribe', _prefix=f'{_prefix}.')
 
-    async def subscribe_forex_minute_aggregates(self, symbols: list = None, handler_function=None, convert_case=True):
+    async def subscribe_forex_minute_aggregates(self, symbols: list = None, handler_function=None, convert_case: bool = True):
         """
         Get Real time Forex Minute Aggregates for provided symbol(s)
 
@@ -740,7 +740,7 @@ class AsyncStreamClient:
         await self._modify_sub(symbols, action='unsubscribe', _prefix=f'{_prefix}.')
 
     # CRYPTO Streams
-    async def subscribe_crypto_trades(self, symbols: list = None, handler_function=None, convert_case=True):
+    async def subscribe_crypto_trades(self, symbols: list = None, handler_function=None, convert_case: bool = True):
         """
         Get Real time Crypto Trades for provided symbol(s)
 
@@ -772,7 +772,7 @@ class AsyncStreamClient:
 
         await self._modify_sub(symbols, action='unsubscribe', _prefix=f'{_prefix}.')
 
-    async def subscribe_crypto_quotes(self, symbols: list = None, handler_function=None, convert_case=True):
+    async def subscribe_crypto_quotes(self, symbols: list = None, handler_function=None, convert_case: bool = True):
         """
         Get Real time Crypto Quotes for provided symbol(s)
 
@@ -804,7 +804,7 @@ class AsyncStreamClient:
 
         await self._modify_sub(symbols, action='unsubscribe', _prefix=f'{_prefix}.')
 
-    async def subscribe_crypto_minute_aggregates(self, symbols: list = None, handler_function=None, convert_case=True):
+    async def subscribe_crypto_minute_aggregates(self, symbols: list = None, handler_function=None, convert_case: bool = True):
         """
         Get Real time Crypto Minute Aggregates for provided symbol(s)
 
@@ -836,7 +836,7 @@ class AsyncStreamClient:
 
         await self._modify_sub(symbols, action='unsubscribe', _prefix=f'{_prefix}.')
 
-    async def subscribe_crypto_level2_book(self, symbols: list = None, handler_function=None, convert_case=True):
+    async def subscribe_crypto_level2_book(self, symbols: list = None, handler_function=None, convert_case: bool = True):
         """
         Get Real time Crypto Level 2 Book Data for provided symbol(s)
 

--- a/polygon/streaming/async_streaming.py
+++ b/polygon/streaming/async_streaming.py
@@ -378,7 +378,7 @@ class AsyncStreamClient:
             symbols = _prefix + '*'
 
         elif isinstance(symbols, list):
-            symbols = ','.join([_prefix + symbol.upper() for symbol in symbols])
+            symbols = ','.join([_prefix + symbol for symbol in symbols])
 
         self._subs.append((symbols, action))
         _payload = '{"action":"%s", "params":"%s"}' % (action.lower(), symbols)

--- a/polygon/streaming/async_streaming.py
+++ b/polygon/streaming/async_streaming.py
@@ -386,7 +386,7 @@ class AsyncStreamClient:
         await self.WS.send(str(_payload))
 
     # STOCK Streams
-    async def subscribe_stock_trades(self, symbols: list = None, handler_function=None):
+    async def subscribe_stock_trades(self, symbols: list = None, handler_function=None, convert_case=True):
         """
         Get Real time trades for provided symbol(s)
 
@@ -414,7 +414,7 @@ class AsyncStreamClient:
 
         await self._modify_sub(symbols, action='unsubscribe', _prefix=f'{_prefix}.')
 
-    async def subscribe_stock_quotes(self, symbols: list = None, handler_function=None):
+    async def subscribe_stock_quotes(self, symbols: list = None, handler_function=None, convert_case=True):
         """
         Get Real time quotes for provided symbol(s)
 
@@ -442,7 +442,7 @@ class AsyncStreamClient:
 
         await self._modify_sub(symbols, action='unsubscribe', _prefix=f'{_prefix}.')
 
-    async def subscribe_stock_minute_aggregates(self, symbols: list = None, handler_function=None):
+    async def subscribe_stock_minute_aggregates(self, symbols: list = None, handler_function=None, convert_case=True):
         """
         Get Real time Minute Aggregates for provided symbol(s)
 
@@ -470,7 +470,7 @@ class AsyncStreamClient:
 
         await self._modify_sub(symbols, action='unsubscribe', _prefix=f'{_prefix}.')
 
-    async def subscribe_stock_second_aggregates(self, symbols: list = None, handler_function=None):
+    async def subscribe_stock_second_aggregates(self, symbols: list = None, handler_function=None, convert_case=True):
         """
         Get Real time Seconds Aggregates for provided symbol(s)
 
@@ -498,7 +498,7 @@ class AsyncStreamClient:
 
         await self._modify_sub(symbols, action='unsubscribe', _prefix=f'{_prefix}.')
 
-    async def subscribe_stock_limit_up_limit_down(self, symbols: list = None, handler_function=None):
+    async def subscribe_stock_limit_up_limit_down(self, symbols: list = None, handler_function=None, convert_case=True):
         """
         Get Real time LULD Events for provided symbol(s)
 
@@ -526,7 +526,7 @@ class AsyncStreamClient:
 
         await self._modify_sub(symbols, action='unsubscribe', _prefix=f'{_prefix}.')
 
-    async def subscribe_stock_imbalances(self, symbols: list = None, handler_function=None):
+    async def subscribe_stock_imbalances(self, symbols: list = None, handler_function=None, convert_case=True):
         """
         Get Real time Imbalance Events for provided symbol(s)
 
@@ -555,7 +555,7 @@ class AsyncStreamClient:
         await self._modify_sub(symbols, action='unsubscribe', _prefix=f'{_prefix}.')
 
     # OPTIONS Streams
-    async def subscribe_option_trades(self, symbols: list = None, handler_function=None):
+    async def subscribe_option_trades(self, symbols: list = None, handler_function=None, convert_case=True):
         """
         Get Real time options trades for provided ticker(s)
 
@@ -585,7 +585,7 @@ class AsyncStreamClient:
 
         await self._modify_sub(symbols, action='unsubscribe', _prefix=f'{_prefix}.')
 
-    async def subscribe_option_quotes(self, symbols: list = None, handler_function=None):
+    async def subscribe_option_quotes(self, symbols: list = None, handler_function=None, convert_case=True):
         """
         Get Real time options quotes for provided ticker(s)
 
@@ -615,7 +615,7 @@ class AsyncStreamClient:
 
         await self._modify_sub(symbols, action='unsubscribe', _prefix=f'{_prefix}.')
 
-    async def subscribe_option_minute_aggregates(self, symbols: list = None, handler_function=None):
+    async def subscribe_option_minute_aggregates(self, symbols: list = None, handler_function=None, convert_case=True):
         """
         Get Real time options minute aggregates for given ticker(s)
 
@@ -645,7 +645,7 @@ class AsyncStreamClient:
 
         await self._modify_sub(symbols, action='unsubscribe', _prefix=f'{_prefix}.')
 
-    async def subscribe_option_second_aggregates(self, symbols: list = None, handler_function=None):
+    async def subscribe_option_second_aggregates(self, symbols: list = None, handler_function=None, convert_case=True):
         """
         Get Real time options second aggregates for given ticker(s)
 
@@ -676,7 +676,7 @@ class AsyncStreamClient:
         await self._modify_sub(symbols, action='unsubscribe', _prefix=f'{_prefix}.')
 
     # FOREX Streams
-    async def subscribe_forex_quotes(self, symbols: list = None, handler_function=None):
+    async def subscribe_forex_quotes(self, symbols: list = None, handler_function=None, convert_case=True):
         """
         Get Real time Forex Quotes for provided symbol(s)
 
@@ -706,7 +706,7 @@ class AsyncStreamClient:
 
         await self._modify_sub(symbols, action='unsubscribe', _prefix=f'{_prefix}.')
 
-    async def subscribe_forex_minute_aggregates(self, symbols: list = None, handler_function=None):
+    async def subscribe_forex_minute_aggregates(self, symbols: list = None, handler_function=None, convert_case=True):
         """
         Get Real time Forex Minute Aggregates for provided symbol(s)
 
@@ -737,7 +737,7 @@ class AsyncStreamClient:
         await self._modify_sub(symbols, action='unsubscribe', _prefix=f'{_prefix}.')
 
     # CRYPTO Streams
-    async def subscribe_crypto_trades(self, symbols: list = None, handler_function=None):
+    async def subscribe_crypto_trades(self, symbols: list = None, handler_function=None, convert_case=True):
         """
         Get Real time Crypto Trades for provided symbol(s)
 
@@ -769,7 +769,7 @@ class AsyncStreamClient:
 
         await self._modify_sub(symbols, action='unsubscribe', _prefix=f'{_prefix}.')
 
-    async def subscribe_crypto_quotes(self, symbols: list = None, handler_function=None):
+    async def subscribe_crypto_quotes(self, symbols: list = None, handler_function=None, convert_case=True):
         """
         Get Real time Crypto Quotes for provided symbol(s)
 
@@ -801,7 +801,7 @@ class AsyncStreamClient:
 
         await self._modify_sub(symbols, action='unsubscribe', _prefix=f'{_prefix}.')
 
-    async def subscribe_crypto_minute_aggregates(self, symbols: list = None, handler_function=None):
+    async def subscribe_crypto_minute_aggregates(self, symbols: list = None, handler_function=None, convert_case=True):
         """
         Get Real time Crypto Minute Aggregates for provided symbol(s)
 
@@ -833,7 +833,7 @@ class AsyncStreamClient:
 
         await self._modify_sub(symbols, action='unsubscribe', _prefix=f'{_prefix}.')
 
-    async def subscribe_crypto_level2_book(self, symbols: list = None, handler_function=None):
+    async def subscribe_crypto_level2_book(self, symbols: list = None, handler_function=None, convert_case=True):
         """
         Get Real time Crypto Level 2 Book Data for provided symbol(s)
 


### PR DESCRIPTION
For some tickers with dashes (for instance BC-PC) we need to subscribe to symbols with lowercase letters (BC-PC becomes BCpC).
Converting to upper case here leads to subscribing to wrong tickers.